### PR TITLE
Release as version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Requires at least: 3.7
 * Tested up to:      5.4
 * Requires PHP:      5.2
-* Stable tag:        0.8.0
+* Stable tag:        1.0.0
 * License:           GPLv2 or later
 * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,7 +64,7 @@ There is none, no configuration necessary.
 
 ## Changelog ##
 
-### 0.8.0 ###
+### 1.0.0 ###
 * Add support for the Gutenberg editor (compatible with the latest WordPress version now)
 
 ### 0.7.5 ###

--- a/inc/class-spcl.php
+++ b/inc/class-spcl.php
@@ -82,7 +82,7 @@ final class SPCL {
 	/**
 	 * Enqueue script for block editor.
 	 *
-	 * @since 0.8.0
+	 * @since 1.0.0
 	 */
 	public static function enqueue_block_editor_asset() {
 		wp_enqueue_script(
@@ -105,7 +105,7 @@ final class SPCL {
 	/**
 	 * Handle the AJAX request coming from the block editor.
 	 *
-	 * @since 0.8.0
+	 * @since 1.0.0
 	 */
 	public static function handle_ajax_request() {
 		// Check if user can edit posts.

--- a/spcl.php
+++ b/spcl.php
@@ -7,7 +7,7 @@
  * Plugin URI:  https://wordpress.org/plugins/spcl/
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     0.8.0
+ * Version:     1.0.0
  * Text Domain: spcl
  *
  * @package spcl
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SPCL_VERSION', '0.8.0' );
+define( 'SPCL_VERSION', '1.0.0' );
 
 // Backend only.
 if ( ! is_admin() ) {


### PR DESCRIPTION
To document that SPCL is stable, we should release the upcoming version as 1.0.0 (instead of planned 0.8.0).