### PR TITLE
Change deployment branch from master to stable and update action

### DIFF
--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -4,7 +4,7 @@ on:
     branches:
     - stable
 jobs:
-  master:
+  stable:
     name: Push to stable
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -2,15 +2,16 @@ name: Plugin asset/readme update
 on:
   push:
     branches:
-    - master
+    - stable
 jobs:
   master:
-    name: Push to master
+    name: Push to stable
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+    - uses: php-actions/composer@v1
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@master
+      uses: 10up/action-wordpress-plugin-asset-update@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -9,10 +9,10 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: php-actions/composer@v1
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              admin, broken, check, links, link checker, maintenance, post, posts, seo
 * Requires at least: 3.7
-* Tested up to:      5.4
+* Tested up to:      5.5
 * Requires PHP:      5.2
 * Stable tag:        1.0.0
 * License:           GPLv2 or later


### PR DESCRIPTION
- Switch to branch "stable" as new target to deploy stable releases.
- Update actions to their current versions which have changed from master to stable or v1/v2, too.

This PR already targets the new default target branch _develop_.

Note: This is directly copied from @stklcode's PR in the Statify repo (https://github.com/pluginkollektiv/statify/pull/173/) which has the new branche structure.

In addition to the action, the README is updated to declare compatibility with WordPress 5.5. This way we can test whether everything works by merging develop into stable after this PR is accepted (expected: the readme in trunk is updated as well).
