### PR TITLE
Fix sending AJAX request too early

### DIFF
--- a/assets/js/notice.js
+++ b/assets/js/notice.js
@@ -52,8 +52,6 @@
 									}
 								)
 							);
-
-							isChecking = false;
 						}
 					}
 				};

--- a/assets/js/notice.js
+++ b/assets/js/notice.js
@@ -5,11 +5,11 @@
 
 		// Listen to changes in the editor.
 		wp.data.subscribe( function() {
-			var isSaving = wp.data.select( 'core/editor' ).isSavingPost();
-
-			if ( isSaving && ! isChecking ) {
-				var postId = wp.data.select( 'core/editor' ).getCurrentPostId();
+			if ( wp.data.select( 'core/editor' ).isSavingPost() ) {
 				isChecking = true;
+			} else if ( isChecking ) {
+				isChecking = false;
+				var postId = wp.data.select( 'core/editor' ).getCurrentPostId();
 
 				// Remove old notices if existent.
 				if ( noticesArray.length !== 0 ) {

--- a/assets/js/notice.js
+++ b/assets/js/notice.js
@@ -1,14 +1,14 @@
 ( function() {
 	wp.domReady( function() {
-		var isChecking = false,
+		var needsCheck = false,
 			noticesArray = [];
 
 		// Listen to changes in the editor.
 		wp.data.subscribe( function() {
 			if ( wp.data.select( 'core/editor' ).isSavingPost() ) {
-				isChecking = true;
-			} else if ( isChecking ) {
-				isChecking = false;
+				needsCheck = true;
+			} else if ( needsCheck ) {
+				needsCheck = false;
 				var postId = wp.data.select( 'core/editor' ).getCurrentPostId();
 
 				// Remove old notices if existent.


### PR DESCRIPTION
In Gutenberg, the AJAX request was sent too early. I changed the code a bit, according to the code example from https://github.com/WordPress/gutenberg/issues/17632#issuecomment-583772895, and now it works fine in my tests.