### PR TITLE
Declare compatibility with WordPress 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              admin, broken, check, links, link checker, maintenance, post, posts, seo
 * Requires at least: 3.7
-* Tested up to:      5.6
+* Tested up to:      5.7
 * Requires PHP:      5.2
 * Stable tag:        1.0.1
 * License:           GPLv2 or later


### PR DESCRIPTION
Testing SPCL 1.0.1 with WordPress 5.7, I couldn't find any issues, so let's updated the `Tested up to` on  wordpress.org.