### PR TITLE
ci: add workflow to run wp plugin checks

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.git
 /.github
 /.wordpress-org
+/dist
 /node_modules
 /vendor
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Directories
 /.github export-ignore
 /.wordpress-org export-ignore
+/dist export-ignore
 /node_modules export-ignore
 /vendor export-ignore
 

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,31 @@
+name: Plugin check
+on:
+  push:
+    branches: [ 'stable', 'release/*' ]
+  pull_request:
+    branches: [ 'stable' ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Build
+        run: composer install --no-interaction
+
+      - name: Package plugin
+        run: |
+          mkdir -p ./dist
+          rsync -rc --exclude-from=.distignore ./ ./dist/spcl --delete --delete-excluded
+
+      - name: Check WP plugin
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./dist/spcl

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /assets/js/*.min.js
+/dist
 /node_modules
 /vendor


### PR DESCRIPTION
Branch name prefix "release/" was chosen just to trigger the workflow.

Current findings, just one (expected) error and some minor warnings.

| Type    | Description                                        | Comment                                     |
|---------|----------------------------------------------------|---------------------------------------------|
| Error   | Tested up to: 5.7 < 6.7                            | should be updated before next release       |
| Warning | Please limit your plugin to 5 tags                 | should be updated, no blocker               |
| Warning | "Plugin URI" header not valid                      | should not point to w.org                   |
| Warning | $in_footer is not set explicitly wp_enqueue_script |                                             |
| Warning | Processing form data without nonce verification    | not critical, just an empty($_GET...) check |
