### PR TITLE
prepare release of v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              admin, broken, check, links, link checker, maintenance, post, posts, seo
 * Requires at least: 3.7
-* Tested up to:      5.7
+* Tested up to:      6.8
 * Requires PHP:      5.2
 * Stable tag:        1.0.1
 * License:           GPLv2 or later

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Requires at least: 3.7
 * Tested up to:      6.8
 * Requires PHP:      5.2
-* Stable tag:        1.0.1
+* Stable tag:        1.0.2
 * License:           GPLv2 or later
 * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,18 +51,22 @@ No, it will just list any broken URLs for you, but it will do so already when yo
 ### Does it matter whether a URL is http or https? ###
 By default the plugin will try to ping both, http and https URLs. If needed, you can change accepted protocols via hook. For example, in order to check only URLs with SSL:
 
-```
-add_filter( 'spcl_acceptable_protocols', 'set_spcl_acceptable_protocols' );
-function set_spcl_acceptable_protocols( $schemes ) {
-	return array( 'https' );
-}
-```
+    add_filter( 'spcl_acceptable_protocols', 'set_spcl_acceptable_protocols' );
+    function set_spcl_acceptable_protocols( $schemes ) {
+        return array( 'https' );
+    }
 
 ### Where’s the settings page? ###
 There is none, no configuration necessary.
 
 
 ## Changelog ##
+
+### 1.0.2 ###
+* Updated build environment
+* Minor code style corrections
+* Include JavaScript in footer
+* Tested up to WordPress 6.8
 
 ### 1.0.1 ###
 * Fix issue that check does work in Gutenberg

--- a/spcl.php
+++ b/spcl.php
@@ -7,7 +7,7 @@
  * Plugin URI:  https://wordpress.org/plugins/spcl/
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.0.1
+ * Version:     1.0.2
  * Text Domain: spcl
  *
  * @package spcl
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SPCL_VERSION', '1.0.1' );
+define( 'SPCL_VERSION', '1.0.2' );
 
 // Backend only.
 if ( ! is_admin() ) {


### PR DESCRIPTION
* Tested with the current WP 6.8 (**very briefly** tested myself on a test site)
* Update version and stable tag
* Add changelog entries

This is just a small maintenance release. 2 minor tweaks (#47, #48) and an updated build environment.

Plugin check action is also running on this PR with just two minor readme warnings. Nothing that could not be changed at any time.

Full diff: https://github.com/pluginkollektiv/spcl/compare/1.0.1...develop