### PR TITLE
docs: fix codeblock in FAQ section of readme (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ No, it will just list any broken URLs for you, but it will do so already when yo
 ### Does it matter whether a URL is http or https? ###
 By default the plugin will try to ping both, http and https URLs. If needed, you can change accepted protocols via hook. For example, in order to check only URLs with SSL:
 
-    add_filter( 'spcl_acceptable_protocols', 'set_spcl_acceptable_protocols' );
-    function set_spcl_acceptable_protocols( $schemes ) {
-        return array( 'https' );
-    }
+`
+add_filter( 'spcl_acceptable_protocols', 'set_spcl_acceptable_protocols' );
+function set_spcl_acceptable_protocols( $schemes ) {
+    return array( 'https' );
+}
+`
 
 ### Where’s the settings page? ###
 There is none, no configuration necessary.


### PR DESCRIPTION
On w.org code-blocks in FAQ are not rendered properly. Using single backticks does not give the best experience in rendered MarkDown, e.g. on GitHub, but it's still readable and it's correctly rendered on the plugin page.

We might want to migrate to a dedicated readme.txt for deployment in the future, but for now let's use the cheap solution so we are not blocked.